### PR TITLE
Ignore discarded tabs

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -10,7 +10,8 @@ const commands = {
 
 async function executeCommand(message, callback = null) {
   const scTabs = await browser.tabs.query({
-    url: soundCloudUrl
+    url: soundCloudUrl,
+    discarded: false
   })
 
   if (scTabs.length === 0) {


### PR DESCRIPTION
When there are no audible tabs (like after pausing) and there are unloaded tabs
present from previous session, `targetTab` points to first unloaded tab and
popup does not get populated with data.

With this PR discarded tabs are completely ignored, and everything else is
the same.